### PR TITLE
Add component layer support

### DIFF
--- a/src/archiveloader.cpp
+++ b/src/archiveloader.cpp
@@ -79,3 +79,37 @@ QString ArchiveLoader::featuresPath(QString base)
 
   return plain_path;
 }
+
+QString ArchiveLoader::componentsPath(QString base)
+{
+  QString plain_path = absPath(base.toLower() + "/components");
+
+  // Ensure components is not a gzipped file. If so, unzip it.
+  QString path = plain_path;
+  QFile file(path);
+
+  if (!file.exists()) { // try .[zZ]
+    file.setFileName(path + ".Z");
+
+    if (file.exists()) {
+      path += ".Z";
+    } else {
+      file.setFileName(path + ".z");
+      if (!file.exists()) {
+        return QString();
+      }
+      path += ".z";
+    }
+
+    QStringList args;
+    args << "-d" << path;
+
+    int ret = QProcess::execute(GZIP_CMD, args);
+
+    if ((ret == -1) || (ret == -2)) {
+      return QString();
+    }
+  }
+
+  return plain_path;
+}

--- a/src/archiveloader.h
+++ b/src/archiveloader.h
@@ -41,6 +41,7 @@ public:
   QString absPath(QString path);
   QStringList listDir(QString filename);
   QString featuresPath(QString base);
+  QString componentsPath(QString base);
 
 private:
   QDir m_dir;

--- a/src/graphicsview/components.cpp
+++ b/src/graphicsview/components.cpp
@@ -1,0 +1,32 @@
+#include "components.h"
+
+#include <QtWidgets>
+
+#include "componentsparser.h"
+#include "record.h"
+#include "context.h"
+
+Components::Components(QString step, QString path) : Symbol("components")
+{
+  ComponentsParser parser(ctx.loader->absPath(path.arg(step)));
+  ComponentsDataStore* ds = parser.parse();
+  if (!ds)
+    return;
+
+  for (ComponentRecord* rec : ds->records()) {
+    Symbol* s = rec->createSymbol();
+    addChild(s);
+    m_symbols.append(s);
+  }
+}
+
+Components::~Components()
+{
+}
+
+void Components::addToScene(QGraphicsScene* scene)
+{
+  for (Symbol* s : m_symbols) {
+    scene->addItem(s);
+  }
+}

--- a/src/graphicsview/components.h
+++ b/src/graphicsview/components.h
@@ -1,0 +1,22 @@
+#ifndef __COMPONENTS_H__
+#define __COMPONENTS_H__
+
+#include "symbol.h"
+#include <QList>
+#include <QString>
+
+class ComponentsDataStore;
+class QGraphicsScene;
+
+class Components : public Symbol {
+public:
+  Components(QString step, QString path);
+  ~Components();
+
+  void addToScene(QGraphicsScene* scene);
+
+private:
+  QList<Symbol*> m_symbols;
+};
+
+#endif /* __COMPONENTS_H__ */

--- a/src/graphicsview/graphicsview.pri
+++ b/src/graphicsview/graphicsview.pri
@@ -2,6 +2,7 @@ HEADERS += \
   graphicsview/graphicslayer.h \
   graphicsview/graphicslayerscene.h \
   graphicsview/layerfeatures.h \
+  graphicsview/components.h \
   graphicsview/layer.h \
   graphicsview/measuregraphicsitem.h \
   graphicsview/notes.h \
@@ -15,6 +16,7 @@ SOURCES += \
   graphicsview/graphicslayerscene.cpp \
   graphicsview/layer.cpp \
   graphicsview/layerfeatures.cpp \
+  graphicsview/components.cpp \
   graphicsview/measuregraphicsitem.cpp \
   graphicsview/notes.cpp \
   graphicsview/odbppgraphicsminimapview.cpp \

--- a/src/graphicsview/layer.cpp
+++ b/src/graphicsview/layer.cpp
@@ -26,12 +26,18 @@
 
 #include "context.h"
 #include "odbppgraphicsscene.h"
+#include "components.h"
 
 Layer::Layer(QString step, QString layer):
   GraphicsLayer(NULL), m_step(step), m_layer(layer), m_notes(NULL)
 {
   GraphicsLayerScene* scene = new GraphicsLayerScene;
-  m_features = new LayerFeatures(step, "steps/%1/layers/" +layer +"/features");
+  QString featurePath = ctx.loader->featuresPath(QString("steps/%1/layers/%2/features").arg(step).arg(layer));
+  if (QFile(featurePath).size() > 0) {
+    m_features = new LayerFeatures(step, "steps/%1/layers/" + layer + "/features");
+  } else {
+    m_features = new Components(step, "steps/%1/layers/" + layer + "/components");
+  }
   m_features->addToScene(scene);
   setLayerScene(scene);
 }

--- a/src/graphicsview/layer.h
+++ b/src/graphicsview/layer.h
@@ -28,6 +28,7 @@
 #include "layerfeatures.h"
 #include "graphicslayer.h"
 #include "graphicslayerscene.h"
+#include "components.h"
 #include "notes.h"
 #include "symbol.h"
 #include <QTextEdit>

--- a/src/gui/jobmatrix.cpp
+++ b/src/gui/jobmatrix.cpp
@@ -105,12 +105,14 @@ void JobMatrix::setMatrix()
       text = "(srl,";
     else if(text == "DOCUMENT")
       text = "(doc,";
-    else if(text == "ROUT")
-      text = "(rt ,";
-    else if(text == "SOLDER_PASTE")
-      text = "(sp ,";
-    else
-      text = "( ,";
+  else if(text == "ROUT")
+    text = "(rt ,";
+  else if(text == "SOLDER_PASTE")
+    text = "(sp ,";
+  else if(text == "COMPONENT")
+    text = "(cmp,";
+  else
+    text = "( ,";
     if(it->second->get("POLARITY") == "POSITIVE")
       text += "p)  ";
     else
@@ -132,9 +134,11 @@ void JobMatrix::setMatrix()
       QString pathTmpl = "steps/%1/layers/%2";
       text = pathTmpl.arg(m_stepNames[i]).arg(layerName);
 
-      if (QFile(ctx.loader->featuresPath(text)).size() == 0) {
-        btn->setText("");
-      }
+        QString fpath = ctx.loader->featuresPath(text);
+        QString cpath = ctx.loader->componentsPath(text);
+        if (QFile(fpath).size() == 0 && QFile(cpath).size() == 0) {
+          btn->setText("");
+        }
     }
     layers++;
   }

--- a/src/parser/componentrecord.cpp
+++ b/src/parser/componentrecord.cpp
@@ -1,0 +1,38 @@
+#include "record.h"
+#include "componentsdatastore.h"
+#include "packagedatastore.h"
+#include "componentsymbol.h"
+#include "context.h"
+#include "nullsymbol.h"
+
+ComponentRecord::ComponentRecord(ComponentsDataStore* ds, const QStringList& param)
+  : Record(ds, AttribData())
+{
+  int i = 0;
+  pkg_ref = param[++i].toInt();
+  x = param[++i].toDouble();
+  y = param[++i].toDouble();
+  rot = param[++i].toDouble();
+  mirror = (param[++i] == "M");
+  comp_name = param[++i];
+  if (param.size() > i+1)
+    part_name = param[++i];
+}
+
+Symbol* ComponentRecord::createSymbol(void) const
+{
+  ComponentsDataStore* cds = static_cast<ComponentsDataStore*>(ds);
+  PackageDataStore* pkgs = cds->packages();
+  if (!pkgs)
+    return new NullSymbol("null", P, AttribData());
+  PackageDataStore::PackageInfo info = pkgs->package(pkg_ref);
+  QRectF rect(info.xmin, info.ymin, info.xmax - info.xmin, info.ymax - info.ymin);
+  Symbol* symbol = new ComponentSymbol(rect);
+  symbol->setPos(x, -y);
+  if (mirror) {
+    QTransform t; t.scale(-1, 1); symbol->setTransform(t, true);
+  }
+  symbol->setRotation(rot);
+  symbol->setToolTip(QString("%1 (%2)").arg(comp_name).arg(part_name));
+  return symbol;
+}

--- a/src/parser/componentsdatastore.cpp
+++ b/src/parser/componentsdatastore.cpp
@@ -1,0 +1,17 @@
+#include "componentsdatastore.h"
+#include "packagedatastore.h"
+#include "record.h"
+
+ComponentsDataStore::ComponentsDataStore() : m_pkgs(NULL)
+{
+}
+
+ComponentsDataStore::~ComponentsDataStore()
+{
+  qDeleteAll(m_records);
+}
+
+void ComponentsDataStore::putRecord(ComponentRecord* rec)
+{
+  m_records.append(rec);
+}

--- a/src/parser/componentsdatastore.h
+++ b/src/parser/componentsdatastore.h
@@ -1,0 +1,33 @@
+#ifndef __COMPONENTS_DATASTORE_H__
+#define __COMPONENTS_DATASTORE_H__
+
+#include "datastore.h"
+#include <QList>
+#include <QString>
+
+class ComponentRecord;
+class PackageDataStore;
+
+class ComponentsDataStore : public DataStore {
+public:
+  ComponentsDataStore();
+  ~ComponentsDataStore();
+
+  void setStepName(const QString& name) { m_step = name; }
+  QString stepName() const { return m_step; }
+
+  void setPackages(PackageDataStore* pkgs) { m_pkgs = pkgs; }
+  PackageDataStore* packages() const { return m_pkgs; }
+
+  void putRecord(ComponentRecord* rec);
+  const QList<ComponentRecord*>& records() const { return m_records; }
+
+  virtual void dump(void) {}
+
+private:
+  QString m_step;
+  PackageDataStore* m_pkgs;
+  QList<ComponentRecord*> m_records;
+};
+
+#endif /* __COMPONENTS_DATASTORE_H__ */

--- a/src/parser/odbpp/cachedparser.h
+++ b/src/parser/odbpp/cachedparser.h
@@ -29,6 +29,8 @@
 #include "datastore.h"
 #include "featuresparser.h"
 #include "fontparser.h"
+#include "packageparser.h"
+#include "packagedatastore.h"
 #include "parser.h"
 #include "structuredtextparser.h"
 
@@ -86,5 +88,6 @@ D* CachedParser<P, D>::realParse(QString filename)
 typedef CachedParser<FeaturesParser, FeaturesDataStore> CachedFeaturesParser;
 typedef CachedParser<FontParser, FontDataStore> CachedFontParser;
 typedef CachedParser<StructuredTextParser, StructuredTextDataStore> CachedStructuredTextParser;
+typedef CachedParser<PackageParser, PackageDataStore> CachedPackageParser;
 
 #endif /* __CACHED_PARSER_H__ */

--- a/src/parser/odbpp/componentsparser.cpp
+++ b/src/parser/odbpp/componentsparser.cpp
@@ -1,0 +1,48 @@
+#include "componentsparser.h"
+#include "packageparser.h"
+#include "cachedparser.h"
+#include "record.h"
+#include "context.h"
+
+#include <QtCore>
+#include <QtDebug>
+#include <QRegularExpression>
+
+ComponentsParser::ComponentsParser(const QString& filename) : Parser(filename)
+{
+}
+
+ComponentsParser::~ComponentsParser()
+{
+}
+
+ComponentsDataStore* ComponentsParser::parse(void)
+{
+  QFile file(m_fileName);
+  if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+    qDebug("parse: can't open `%s' for reading", qPrintable(m_fileName));
+    return NULL;
+  }
+
+  ComponentsDataStore* ds = new ComponentsDataStore;
+
+  QRegularExpression rx("^.*/steps/([^/]+)/layers/.*");
+  QRegularExpressionMatch m = rx.match(m_fileName);
+  if (m.hasMatch()) {
+    QString step = m.captured(1);
+    ds->setStepName(step);
+    QString pkgPath = ctx.loader->absPath(QString("steps/%1/eda/data").arg(step));
+    ds->setPackages(CachedPackageParser::parse(pkgPath));
+  }
+
+  while (!file.atEnd()) {
+    QString line = file.readLine().trimmed();
+    if (line.startsWith("CMP")) {
+      QString record = line.section(';',0,0).trimmed();
+      QStringList p = record.split(QRegularExpression("\\s+"), Qt::SkipEmptyParts);
+      ComponentRecord* rec = new ComponentRecord(ds, p);
+      ds->putRecord(rec);
+    }
+  }
+  return ds;
+}

--- a/src/parser/odbpp/componentsparser.h
+++ b/src/parser/odbpp/componentsparser.h
@@ -1,0 +1,15 @@
+#ifndef __COMPONENTS_PARSER_H__
+#define __COMPONENTS_PARSER_H__
+
+#include "parser.h"
+#include "componentsdatastore.h"
+
+class ComponentsParser : public Parser {
+public:
+  ComponentsParser(const QString& filename);
+  virtual ~ComponentsParser();
+
+  virtual ComponentsDataStore* parse(void);
+};
+
+#endif /* __COMPONENTS_PARSER_H__ */

--- a/src/parser/odbpp/odbpp.pri
+++ b/src/parser/odbpp/odbpp.pri
@@ -6,6 +6,8 @@ HEADERS += \
   parser/odbpp/featuresparser.h \
   parser/odbpp/fontparser.h \
   parser/odbpp/notesparser.h \
+  parser/odbpp/packageparser.h \
+  parser/odbpp/componentsparser.h \
   parser/odbpp/structuredtextparser.h \
   parser/odbpp/yyheader.h
 
@@ -13,6 +15,8 @@ SOURCES += \
   parser/odbpp/featuresparser.cpp \
   parser/odbpp/fontparser.cpp \
   parser/odbpp/notesparser.cpp \
+  parser/odbpp/packageparser.cpp \
+  parser/odbpp/componentsparser.cpp \
   parser/odbpp/structuredtextparser.cpp
 
 FLEXSOURCES += parser/odbpp/db.l

--- a/src/parser/odbpp/packageparser.cpp
+++ b/src/parser/odbpp/packageparser.cpp
@@ -1,0 +1,44 @@
+#include "packageparser.h"
+
+#include <QtCore>
+#include <QRegularExpression>
+#include <QtDebug>
+
+PackageParser::PackageParser(const QString& filename) : Parser(filename)
+{
+}
+
+PackageParser::~PackageParser()
+{
+}
+
+PackageDataStore* PackageParser::parse(void)
+{
+  QFile file(m_fileName);
+  if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+    qDebug("parse: can't open `%s' for reading", qPrintable(m_fileName));
+    return NULL;
+  }
+
+  PackageDataStore* ds = new PackageDataStore;
+  int index = -1;
+  while (!file.atEnd()) {
+    QString line = file.readLine().trimmed();
+    if (line.startsWith("PKG")) {
+      ++index;
+      QString record = line.section(';', 0, 0).trimmed();
+      QStringList p = record.split(QRegularExpression("\\s+"), Qt::SkipEmptyParts);
+      if (p.size() >= 7) {
+        PackageDataStore::PackageInfo info;
+        info.name = p[1];
+        info.pitch = p[2].toDouble();
+        info.xmin = p[3].toDouble();
+        info.ymin = p[4].toDouble();
+        info.xmax = p[5].toDouble();
+        info.ymax = p[6].toDouble();
+        ds->addPackage(index, info);
+      }
+    }
+  }
+  return ds;
+}

--- a/src/parser/odbpp/packageparser.h
+++ b/src/parser/odbpp/packageparser.h
@@ -1,0 +1,15 @@
+#ifndef __PACKAGE_PARSER_H__
+#define __PACKAGE_PARSER_H__
+
+#include "parser.h"
+#include "packagedatastore.h"
+
+class PackageParser : public Parser {
+public:
+  PackageParser(const QString& filename);
+  virtual ~PackageParser();
+
+  virtual PackageDataStore* parse(void);
+};
+
+#endif /* __PACKAGE_PARSER_H__ */

--- a/src/parser/packagedatastore.cpp
+++ b/src/parser/packagedatastore.cpp
@@ -1,0 +1,11 @@
+#include "packagedatastore.h"
+
+void PackageDataStore::addPackage(int index, const PackageInfo& info)
+{
+  m_packages[index] = info;
+}
+
+PackageDataStore::PackageInfo PackageDataStore::package(int index) const
+{
+  return m_packages.value(index);
+}

--- a/src/parser/packagedatastore.h
+++ b/src/parser/packagedatastore.h
@@ -1,0 +1,30 @@
+#ifndef __PACKAGE_DATASTORE_H__
+#define __PACKAGE_DATASTORE_H__
+
+#include "datastore.h"
+#include <QMap>
+#include <QString>
+#include <QRectF>
+
+class PackageDataStore : public DataStore {
+public:
+  struct PackageInfo {
+    QString name;
+    qreal pitch;
+    qreal xmin;
+    qreal ymin;
+    qreal xmax;
+    qreal ymax;
+  };
+
+  void addPackage(int index, const PackageInfo& info);
+  PackageInfo package(int index) const;
+  const QMap<int, PackageInfo>& packages() const { return m_packages; }
+
+  virtual void dump(void) {}
+
+private:
+  QMap<int, PackageInfo> m_packages;
+};
+
+#endif /* __PACKAGE_DATASTORE_H__ */

--- a/src/parser/parser.pri
+++ b/src/parser/parser.pri
@@ -6,6 +6,8 @@ HEADERS += \
   parser/code39.h \
   parser/featuresdatastore.h \
   parser/fontdatastore.h \
+  parser/packagedatastore.h \
+  parser/componentsdatastore.h \
   parser/datastore.h \
   parser/notesdatastore.h \
   parser/structuredtextdatastore.h
@@ -20,8 +22,11 @@ SOURCES += \
   parser/arcrecord.cpp \
   parser/charrecord.cpp \
   parser/noterecord.cpp \
+  parser/componentrecord.cpp \
   parser/code39.cpp \
   parser/featuresdatastore.cpp \
   parser/fontdatastore.cpp \
+  parser/packagedatastore.cpp \
+  parser/componentsdatastore.cpp \
   parser/notesdatastore.cpp \
   parser/structuredtextdatastore.cpp

--- a/src/parser/record.h
+++ b/src/parser/record.h
@@ -36,6 +36,7 @@ class DataStore;
 class FeaturesDataStore;
 class FontDataStore;
 class NotesDataStore;
+class ComponentsDataStore;
 
 struct Record {
   Record(DataStore* _ds, const AttribData& attr): ds(_ds), attrib(attr) {}
@@ -187,6 +188,18 @@ struct NoteRecord: public Record {
   QString user;
   qreal x, y;
   QString text;
+};
+
+struct ComponentRecord: public Record {
+  ComponentRecord(ComponentsDataStore* ds, const QStringList& param);
+  virtual Symbol* createSymbol(void) const;
+
+  int pkg_ref;
+  qreal x, y;
+  qreal rot;
+  bool mirror;
+  QString comp_name;
+  QString part_name;
 };
 
 #endif /* __RECORD_H__ */

--- a/src/symbol/componentsymbol.cpp
+++ b/src/symbol/componentsymbol.cpp
@@ -1,0 +1,16 @@
+#include "componentsymbol.h"
+
+#include <QtWidgets>
+
+ComponentSymbol::ComponentSymbol(const QRectF& rect)
+  : Symbol("component"), m_rect(rect)
+{
+  m_bounding = QRectF(m_rect.left(), -m_rect.bottom(), m_rect.width(), m_rect.height());
+}
+
+QPainterPath ComponentSymbol::painterPath(void)
+{
+  QPainterPath path;
+  path.addRect(QRectF(m_rect.left(), -m_rect.bottom(), m_rect.width(), m_rect.height()));
+  return path;
+}

--- a/src/symbol/componentsymbol.h
+++ b/src/symbol/componentsymbol.h
@@ -1,0 +1,15 @@
+#ifndef __COMPONENT_SYMBOL_H__
+#define __COMPONENT_SYMBOL_H__
+
+#include "symbol.h"
+#include <QRectF>
+
+class ComponentSymbol : public Symbol {
+public:
+  ComponentSymbol(const QRectF& rect);
+  virtual QPainterPath painterPath(void);
+private:
+  QRectF m_rect;
+};
+
+#endif /* __COMPONENT_SYMBOL_H__ */

--- a/src/symbol/symbol.pri
+++ b/src/symbol/symbol.pri
@@ -32,6 +32,7 @@ HEADERS += \
   symbol/linesymbol.h \
   symbol/notesymbol.h \
   symbol/surfacesymbol.h \
+  symbol/componentsymbol.h \
   symbol/textsymbol.h \
   symbol/symbolfactory.h
 
@@ -69,4 +70,5 @@ SOURCES += \
   symbol/linesymbol.cpp \
   symbol/notesymbol.cpp \
   symbol/surfacesymbol.cpp \
+  symbol/componentsymbol.cpp \
   symbol/textsymbol.cpp


### PR DESCRIPTION
## Summary
- support extracting component layer files from ODB++ archives
- display component layers in job matrix like other layers
- parse package data for bounding boxes and parse components
- render component outlines in viewer using new Components layer

## Testing
- `qmake6`
- `make -j$(nproc)`

------
https://chatgpt.com/codex/tasks/task_e_684053e7ecf48333a7b37cd95fa39a55