### PR TITLE
Render components with pin outlines

### DIFF
--- a/src/parser/componentrecord.cpp
+++ b/src/parser/componentrecord.cpp
@@ -26,8 +26,7 @@ Symbol* ComponentRecord::createSymbol(void) const
   if (!pkgs)
     return new NullSymbol("null", P, AttribData());
   PackageDataStore::PackageInfo info = pkgs->package(pkg_ref);
-  QRectF rect(info.xmin, info.ymin, info.xmax - info.xmin, info.ymax - info.ymin);
-  Symbol* symbol = new ComponentSymbol(rect);
+  Symbol* symbol = new ComponentSymbol(info);
   symbol->setPos(x, -y);
   if (mirror) {
     QTransform t; t.scale(-1, 1); symbol->setTransform(t, true);

--- a/src/parser/odbpp/packageparser.cpp
+++ b/src/parser/odbpp/packageparser.cpp
@@ -22,23 +22,117 @@ PackageDataStore* PackageParser::parse(void)
 
   PackageDataStore* ds = new PackageDataStore;
   int index = -1;
+  PackageDataStore::PackageInfo info;
+  PackageDataStore::PackageInfo::PinInfo currentPin;
+  bool inPin = false;
+  QPainterPath path;
+
+  auto finalizePath = [&]() {
+    if (path.elementCount() == 0)
+      return;
+    if (inPin) {
+      currentPin.path.addPath(path);
+    } else {
+      info.bodyPath.addPath(path);
+    }
+    path = QPainterPath();
+  };
+
+  auto finalizePin = [&]() {
+    if (inPin) {
+      finalizePath();
+      info.pins.append(currentPin);
+      inPin = false;
+    }
+  };
+
   while (!file.atEnd()) {
     QString line = file.readLine().trimmed();
+
     if (line.startsWith("PKG")) {
+      finalizePin();
+      if (index >= 0)
+        ds->addPackage(index, info);
+
       ++index;
+      info = PackageDataStore::PackageInfo();
+      info.bodyPath = QPainterPath();
+      info.pins.clear();
       QString record = line.section(';', 0, 0).trimmed();
       QStringList p = record.split(QRegularExpression("\\s+"), Qt::SkipEmptyParts);
       if (p.size() >= 7) {
-        PackageDataStore::PackageInfo info;
         info.name = p[1];
         info.pitch = p[2].toDouble();
         info.xmin = p[3].toDouble();
         info.ymin = p[4].toDouble();
         info.xmax = p[5].toDouble();
         info.ymax = p[6].toDouble();
-        ds->addPackage(index, info);
+      }
+    } else if (line.startsWith("PIN")) {
+      finalizePin();
+      QString record = line.section(';', 0, 0).trimmed();
+      QStringList p = record.split(QRegularExpression("\\s+"), Qt::SkipEmptyParts);
+      if (p.size() >= 5) {
+        currentPin = PackageDataStore::PackageInfo::PinInfo();
+        currentPin.number = p[1].toInt();
+        currentPin.x = p[3].toDouble();
+        currentPin.y = p[4].toDouble();
+        currentPin.path = QPainterPath();
+        inPin = true;
+      }
+    } else if (line.startsWith("CT")) {
+      finalizePath();
+    } else if (line.startsWith("OB")) {
+      QStringList p = line.split(QRegularExpression("\\s+"), Qt::SkipEmptyParts);
+      if (p.size() >= 3) {
+        qreal x = p[1].toDouble();
+        qreal y = p[2].toDouble();
+        path.moveTo(x, -y);
+      }
+    } else if (line.startsWith("OS")) {
+      QStringList p = line.split(QRegularExpression("\\s+"), Qt::SkipEmptyParts);
+      if (p.size() >= 3) {
+        qreal x = p[1].toDouble();
+        qreal y = p[2].toDouble();
+        path.lineTo(x, -y);
+      }
+    } else if (line.startsWith("OE")) {
+      path.closeSubpath();
+    } else if (line.startsWith("CE")) {
+      finalizePath();
+    } else if (line.startsWith("RC")) {
+      QStringList p = line.split(QRegularExpression("\\s+"), Qt::SkipEmptyParts);
+      if (p.size() >= 5) {
+        qreal x = p[1].toDouble();
+        qreal y = p[2].toDouble();
+        qreal w = p[3].toDouble();
+        qreal h = p[4].toDouble();
+        QPainterPath rcPath;
+        rcPath.addRect(QRectF(x, -y - h, w, h));
+        if (inPin)
+          currentPin.path.addPath(rcPath);
+        else
+          info.bodyPath.addPath(rcPath);
+      }
+    } else if (line.startsWith("CR")) {
+      QStringList p = line.split(QRegularExpression("\\s+"), Qt::SkipEmptyParts);
+      if (p.size() >= 4) {
+        qreal x = p[1].toDouble();
+        qreal y = p[2].toDouble();
+        qreal r = p[3].toDouble();
+        QPainterPath crPath;
+        crPath.addEllipse(QPointF(x, -y), r, r);
+        if (inPin)
+          currentPin.path.addPath(crPath);
+        else
+          info.bodyPath.addPath(crPath);
       }
     }
   }
+
+  finalizePin();
+  if (index >= 0)
+    ds->addPackage(index, info);
+
   return ds;
 }

--- a/src/parser/packagedatastore.h
+++ b/src/parser/packagedatastore.h
@@ -5,6 +5,7 @@
 #include <QMap>
 #include <QString>
 #include <QRectF>
+#include <QPainterPath>
 
 class PackageDataStore : public DataStore {
 public:
@@ -15,6 +16,15 @@ public:
     qreal ymin;
     qreal xmax;
     qreal ymax;
+
+    QPainterPath bodyPath;
+    struct PinInfo {
+      int number;
+      qreal x;
+      qreal y;
+      QPainterPath path;
+    };
+    QList<PinInfo> pins;
   };
 
   void addPackage(int index, const PackageInfo& info);

--- a/src/symbol/componentsymbol.cpp
+++ b/src/symbol/componentsymbol.cpp
@@ -1,16 +1,28 @@
 #include "componentsymbol.h"
-
 #include <QtWidgets>
 
-ComponentSymbol::ComponentSymbol(const QRectF& rect)
-  : Symbol("component"), m_rect(rect)
+ComponentSymbol::ComponentSymbol(const PackageDataStore::PackageInfo& info)
+  : Symbol("component"), m_pin1(0,0)
 {
-  m_bounding = QRectF(m_rect.left(), -m_rect.bottom(), m_rect.width(), m_rect.height());
+  m_path = info.bodyPath;
+  for (const auto& pin : info.pins) {
+    m_path.addPath(pin.path);
+    if (pin.number == 1)
+      m_pin1 = QPointF(pin.x, -pin.y);
+  }
+  m_bounding = m_path.boundingRect();
 }
 
 QPainterPath ComponentSymbol::painterPath(void)
 {
-  QPainterPath path;
-  path.addRect(QRectF(m_rect.left(), -m_rect.bottom(), m_rect.width(), m_rect.height()));
-  return path;
+  return m_path;
+}
+
+void ComponentSymbol::paint(QPainter *painter, const QStyleOptionGraphicsItem *option,
+    QWidget *widget)
+{
+  Symbol::paint(painter, option, widget);
+  painter->setPen(Qt::NoPen);
+  painter->setBrush(m_pen);
+  painter->drawEllipse(m_pin1, 0.02, 0.02);
 }

--- a/src/symbol/componentsymbol.h
+++ b/src/symbol/componentsymbol.h
@@ -2,14 +2,18 @@
 #define __COMPONENT_SYMBOL_H__
 
 #include "symbol.h"
-#include <QRectF>
+#include "packagedatastore.h"
+#include <QPainterPath>
 
 class ComponentSymbol : public Symbol {
 public:
-  ComponentSymbol(const QRectF& rect);
+  ComponentSymbol(const PackageDataStore::PackageInfo& info);
   virtual QPainterPath painterPath(void);
+  virtual void paint(QPainter *painter, const QStyleOptionGraphicsItem *option,
+                     QWidget *widget);
 private:
-  QRectF m_rect;
+  QPainterPath m_path;
+  QPointF m_pin1;
 };
 
 #endif /* __COMPONENT_SYMBOL_H__ */


### PR DESCRIPTION
## Summary
- extend `PackageDataStore` to hold body and pin geometry
- parse component packages for outlines and pins
- render pins and body outline in `ComponentSymbol`
- use package geometry when creating component graphics

## Testing
- `qmake -o Makefile src.pro` *(fails: `bison: No such file or directory`)*
- `make -j$(nproc)` *(fails: `bison: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_68406b94300083338fe018bce5a2a68c