### PR TITLE
Fix build with Qt6

### DIFF
--- a/src/symbol/componentsymbol.cpp
+++ b/src/symbol/componentsymbol.cpp
@@ -23,6 +23,6 @@ void ComponentSymbol::paint(QPainter *painter, const QStyleOptionGraphicsItem *o
 {
   Symbol::paint(painter, option, widget);
   painter->setPen(Qt::NoPen);
-  painter->setBrush(m_pen);
+  painter->setBrush(QBrush(m_pen.color()));
   painter->drawEllipse(m_pin1, 0.02, 0.02);
 }

--- a/src/test.pro
+++ b/src/test.pro
@@ -1,4 +1,5 @@
 TEMPLATE = app
+QT += widgets
 
 MOC_DIR = .build
 UI_DIR = .build
@@ -25,7 +26,7 @@ SOURCES += \
   settings.cpp \
   symbolpool.cpp
 
-INCLUDEPATH += . .build parser parser/record symbol gui graphicsview
+INCLUDEPATH += . .build parser parser/odbpp parser/record symbol gui graphicsview
 
 DESTDIR = ../bin
 TARGET = test

--- a/src/tests/testviewwidget.cpp
+++ b/src/tests/testviewwidget.cpp
@@ -39,12 +39,12 @@ TestViewWidget::TestViewWidget(QWidget* parent): QGraphicsView(parent)
 
 void TestViewWidget::wheelEvent(QWheelEvent *event)
 {
-    scaleView(pow((double)2, -event->delta() / 240.0));
+    const int delta = event->angleDelta().y();
+    scaleView(std::pow(2.0, -delta / 240.0));
 }
 
 void TestViewWidget::scaleView(qreal scaleFactor)
 {
-    qreal factor = transform().scale(scaleFactor, scaleFactor).mapRect(QRectF(0, 0, 1, 1)).width();
-
+    Q_UNUSED(scaleFactor);
     scale(scaleFactor, scaleFactor);
 }


### PR DESCRIPTION
## Summary
- fix invalid painter brush usage
- update test project for Qt6
- modernize QWheelEvent code for Qt6

## Testing
- `qmake qcamber.pro -o Makefile && make -j$(nproc)`
- `qmake src/test.pro -o Makefile.test && make -f Makefile.test -j$(nproc)`
- `timeout 5s ../bin/test -platform offscreen`

------
https://chatgpt.com/codex/tasks/task_e_6840713d8c108333bcf0027cc52f8923