### PR TITLE
Improve setup script for build environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# AGENT INSTRUCTIONS
+
+## Testing
+- Run `bash -n setup.sh` for syntax check.
+- Run `./setup.sh` to install build dependencies.
+- Run `qmake6 -version` to verify qmake6 is installed.
+- Run `make -j2` from the repository root; expected to fail due to missing Qt modules if environment is not fully satisfied.

--- a/setup.sh
+++ b/setup.sh
@@ -1,32 +1,41 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-set -e
+# Script to prepare the build environment for QCamber.
+# It installs the required Qt6 development packages along with
+# additional build tools such as qmake6, bison and flex.
+
+set -euo pipefail
+
+# Avoid interactive prompts during installation
+export DEBIAN_FRONTEND=noninteractive
 
 echo "Updating package lists..."
-sudo apt update
+sudo apt-get update
 
-echo "Installing Qt6 development packages and tools..."
-sudo apt install -y \
-  qt6-base-dev \
-  qt6-tools-dev \
-  qt6-tools-dev-tools \
-  qt6-l10n-tools \
-  qt6-base-dev-tools \
-  qt6-declarative-dev \
-  qt6-multimedia-dev \
-  qt6-svg-dev \
-  qt6-tools-tools \
-  qmake6 \
-  bison \
-  flex \
-  build-essential \
-  cmake \
+packages=(
+  qt6-base-dev
+  qt6-tools-dev
+  qt6-tools-dev-tools
+  qt6-l10n-tools
+  qt6-base-dev-tools
+  qt6-declarative-dev
+  qt6-multimedia-dev
+  qt6-svg-dev
+  qmake6
+  bison
+  flex
+  build-essential
+  cmake
   git
+)
 
-echo "Ensuring qmake6 is available via 'qmake' (optional)..."
+echo "Installing build dependencies..."
+sudo apt-get install -y --no-install-recommends "${packages[@]}"
+
+# Provide a qmake wrapper if qmake6 is installed but qmake is not.
 if ! command -v qmake >/dev/null && command -v qmake6 >/dev/null; then
     echo "Creating symbolic link: /usr/local/bin/qmake -> qmake6"
-    sudo ln -s $(command -v qmake6) /usr/local/bin/qmake
+    sudo ln -sf "$(command -v qmake6)" /usr/local/bin/qmake
 fi
 
 echo "Environment setup complete."


### PR DESCRIPTION
## Summary
- enhance setup script robustness
- add noninteractive apt install options
- fix Qt package list
- create AGENTS.md with instructions

## Testing
- `bash -n setup.sh`
- `bash setup.sh`
- `qmake6 -version`
- `make -j2` *(fails: No targets)*

------
https://chatgpt.com/codex/tasks/task_e_68407e6fecec8333a0b2ad05ad01c19d