### PR TITLE
Add designator text to component symbols

### DIFF
--- a/src/parser/componentrecord.cpp
+++ b/src/parser/componentrecord.cpp
@@ -26,7 +26,7 @@ Symbol* ComponentRecord::createSymbol(void) const
   if (!pkgs)
     return new NullSymbol("null", P, AttribData());
   PackageDataStore::PackageInfo info = pkgs->package(pkg_ref);
-  Symbol* symbol = new ComponentSymbol(info);
+  Symbol* symbol = new ComponentSymbol(info, comp_name);
   symbol->setPos(x, -y);
   if (mirror) {
     QTransform t; t.scale(-1, 1); symbol->setTransform(t, true);

--- a/src/symbol/componentsymbol.cpp
+++ b/src/symbol/componentsymbol.cpp
@@ -1,8 +1,9 @@
 #include "componentsymbol.h"
 #include <QtWidgets>
 
-ComponentSymbol::ComponentSymbol(const PackageDataStore::PackageInfo& info)
-  : Symbol("component"), m_pin1(0,0)
+ComponentSymbol::ComponentSymbol(const PackageDataStore::PackageInfo& info,
+                                 const QString& designator)
+  : Symbol("component"), m_pin1(0,0), m_designator(designator)
 {
   m_path = info.bodyPath;
   for (const auto& pin : info.pins) {
@@ -24,5 +25,8 @@ void ComponentSymbol::paint(QPainter *painter, const QStyleOptionGraphicsItem *o
   Symbol::paint(painter, option, widget);
   painter->setPen(Qt::NoPen);
   painter->setBrush(QBrush(m_pen.color()));
-  painter->drawEllipse(m_pin1, 0.02, 0.02);
+  painter->drawEllipse(m_pin1, 0.01, 0.01);
+  painter->setPen(m_pen);
+  painter->setBrush(Qt::NoBrush);
+  painter->drawText(m_bounding, Qt::AlignCenter, m_designator);
 }

--- a/src/symbol/componentsymbol.h
+++ b/src/symbol/componentsymbol.h
@@ -7,13 +7,15 @@
 
 class ComponentSymbol : public Symbol {
 public:
-  ComponentSymbol(const PackageDataStore::PackageInfo& info);
+  ComponentSymbol(const PackageDataStore::PackageInfo& info,
+                  const QString& designator);
   virtual QPainterPath painterPath(void);
   virtual void paint(QPainter *painter, const QStyleOptionGraphicsItem *option,
                      QWidget *widget);
 private:
   QPainterPath m_path;
   QPointF m_pin1;
+  QString m_designator;
 };
 
 #endif /* __COMPONENT_SYMBOL_H__ */


### PR DESCRIPTION
## Summary
- show component designator in component symbol
- shrink pin 1 marker

## Testing
- `bash -n setup.sh`
- `bash setup.sh`
- `qmake6 -version`
- `make -j2` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_684080dd91708333a0860d4e14d19e8e