### PR TITLE
Fix component designator rendering and layer detection

### DIFF
--- a/src/graphicsview/layer.cpp
+++ b/src/graphicsview/layer.cpp
@@ -32,7 +32,7 @@ Layer::Layer(QString step, QString layer):
   GraphicsLayer(NULL), m_step(step), m_layer(layer), m_notes(NULL)
 {
   GraphicsLayerScene* scene = new GraphicsLayerScene;
-  QString featurePath = ctx.loader->featuresPath(QString("steps/%1/layers/%2/features").arg(step).arg(layer));
+  QString featurePath = ctx.loader->featuresPath(QString("steps/%1/layers/%2").arg(step).arg(layer));
   if (QFile(featurePath).size() > 0) {
     m_features = new LayerFeatures(step, "steps/%1/layers/" + layer + "/features");
   } else {

--- a/src/symbol/componentsymbol.cpp
+++ b/src/symbol/componentsymbol.cpp
@@ -12,6 +12,12 @@ ComponentSymbol::ComponentSymbol(const PackageDataStore::PackageInfo& info,
       m_pin1 = QPointF(pin.x, -pin.y);
   }
   m_bounding = m_path.boundingRect();
+  if (!m_designator.isEmpty()) {
+    QFontMetricsF fm(QApplication::font());
+    QRectF textRect = fm.boundingRect(m_designator);
+    textRect.moveCenter(m_bounding.center());
+    m_bounding = m_bounding.united(textRect);
+  }
 }
 
 QPainterPath ComponentSymbol::painterPath(void)


### PR DESCRIPTION
## Summary
- correct path to feature files so layers render
- enlarge component bounding box to display designator text

## Testing
- `bash -n setup.sh`
- `bash ./setup.sh`
- `qmake6 -version`
- `qmake6 qcamber.pro`
- `make -j2`

------
https://chatgpt.com/codex/tasks/task_e_684082903f1c833396b3e92172ee5ca6