### PR TITLE
Fix designator font size and add agent notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,3 +5,6 @@
 - Run `./setup.sh` to install build dependencies.
 - Run `qmake6 -version` to verify qmake6 is installed.
 - Run `make -j2` from the repository root; expected to fail due to missing Qt modules if environment is not fully satisfied.
+
+## Notes
+- Check `AGENT_NOTES.md` for environment reminders before running commands.

--- a/AGENT_NOTES.md
+++ b/AGENT_NOTES.md
@@ -1,0 +1,5 @@
+# Agent Notes
+
+- Remember: run the setup steps as described in AGENTS.md.
+- Add any environment setup or troubleshooting notes here.
+

--- a/src/symbol/componentsymbol.cpp
+++ b/src/symbol/componentsymbol.cpp
@@ -5,6 +5,12 @@ ComponentSymbol::ComponentSymbol(const PackageDataStore::PackageInfo& info,
                                  const QString& designator)
   : Symbol("component"), m_pin1(0,0), m_designator(designator)
 {
+  m_designatorFont = QApplication::font();
+  if (m_designatorFont.pointSizeF() > 0)
+    m_designatorFont.setPointSizeF(m_designatorFont.pointSizeF() * 0.5);
+  else if (m_designatorFont.pixelSize() > 0)
+    m_designatorFont.setPixelSize(m_designatorFont.pixelSize() * 0.5);
+
   m_path = info.bodyPath;
   for (const auto& pin : info.pins) {
     m_path.addPath(pin.path);
@@ -13,7 +19,7 @@ ComponentSymbol::ComponentSymbol(const PackageDataStore::PackageInfo& info,
   }
   m_bounding = m_path.boundingRect();
   if (!m_designator.isEmpty()) {
-    QFontMetricsF fm(QApplication::font());
+    QFontMetricsF fm(m_designatorFont);
     QRectF textRect = fm.boundingRect(m_designator);
     textRect.moveCenter(m_bounding.center());
     m_bounding = m_bounding.united(textRect);
@@ -34,5 +40,8 @@ void ComponentSymbol::paint(QPainter *painter, const QStyleOptionGraphicsItem *o
   painter->drawEllipse(m_pin1, 0.01, 0.01);
   painter->setPen(m_pen);
   painter->setBrush(Qt::NoBrush);
+  QFont prevFont = painter->font();
+  painter->setFont(m_designatorFont);
   painter->drawText(m_bounding, Qt::AlignCenter, m_designator);
+  painter->setFont(prevFont);
 }

--- a/src/symbol/componentsymbol.h
+++ b/src/symbol/componentsymbol.h
@@ -16,6 +16,7 @@ private:
   QPainterPath m_path;
   QPointF m_pin1;
   QString m_designator;
+  QFont m_designatorFont;
 };
 
 #endif /* __COMPONENT_SYMBOL_H__ */


### PR DESCRIPTION
## Summary
- shrink component designator text size in `ComponentSymbol`
- add AGENT_NOTES.md file for environment notes
- remind agent to check the notes file via AGENTS.md

## Testing
- `bash -n setup.sh`
- `bash setup.sh`
- `qmake6 -version`
- `make -j2` *(fails: No targets specified)*

------
https://chatgpt.com/codex/tasks/task_e_684085cc1ddc8333b8f723c748468407