### PR TITLE
Fix component designator text size

### DIFF
--- a/src/symbol/componentsymbol.cpp
+++ b/src/symbol/componentsymbol.cpp
@@ -7,9 +7,9 @@ ComponentSymbol::ComponentSymbol(const PackageDataStore::PackageInfo& info,
 {
   m_designatorFont = QApplication::font();
   if (m_designatorFont.pointSizeF() > 0)
-    m_designatorFont.setPointSizeF(m_designatorFont.pointSizeF() * 0.5);
+    m_designatorFont.setPointSizeF(m_designatorFont.pointSizeF() * 0.3);
   else if (m_designatorFont.pixelSize() > 0)
-    m_designatorFont.setPixelSize(m_designatorFont.pixelSize() * 0.5);
+    m_designatorFont.setPixelSize(m_designatorFont.pixelSize() * 0.3);
 
   m_path = info.bodyPath;
   for (const auto& pin : info.pins) {


### PR DESCRIPTION
## Summary
- reduce component designator text size

## Testing
- `bash -n setup.sh`
- `bash ./setup.sh`
- `qmake6 -version`
- `make -j2` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_6840874859e8833394712cf94b848793