### PR TITLE
Fix missing component designator

### DIFF
--- a/src/symbol/componentsymbol.cpp
+++ b/src/symbol/componentsymbol.cpp
@@ -12,12 +12,19 @@ ComponentSymbol::ComponentSymbol(const PackageDataStore::PackageInfo& info,
       m_pin1 = QPointF(pin.x, -pin.y);
   }
   m_bounding = m_path.boundingRect();
+  if (m_bounding.isNull() && info.xmax > info.xmin && info.ymax > info.ymin)
+    m_bounding = QRectF(info.xmin, -info.ymax,
+                        info.xmax - info.xmin, info.ymax - info.ymin);
 
   m_designatorFont = QApplication::font();
   QFontMetricsF baseFm(m_designatorFont);
   qreal baseHeight = baseFm.height();
   if (baseHeight > 0) {
-    qreal targetHeight = m_bounding.height() * 0.25;
+    qreal boundHeight = m_bounding.height();
+    qreal pkgHeight = info.ymax - info.ymin;
+    if (pkgHeight > boundHeight)
+      boundHeight = pkgHeight;
+    qreal targetHeight = boundHeight * 0.25;
     qreal scaleFactor = targetHeight / baseHeight;
     if (m_designatorFont.pointSizeF() > 0)
       m_designatorFont.setPointSizeF(m_designatorFont.pointSizeF() * scaleFactor);


### PR DESCRIPTION
## Summary
- ensure component symbol calculates bounding box even if no body path exists
- scale designator text using component bounding box

## Testing
- `bash -n setup.sh`
- `qmake6 -version`
- `make -j2` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68408b5fc70c8333899070d5306d716a