### PR TITLE
Fix component outline rendering

### DIFF
--- a/src/symbol/componentsymbol.cpp
+++ b/src/symbol/componentsymbol.cpp
@@ -1,11 +1,14 @@
 #include "componentsymbol.h"
 #include <QtWidgets>
+#include "graphicslayerscene.h"
 
 ComponentSymbol::ComponentSymbol(const PackageDataStore::PackageInfo& info,
                                  const QString& designator)
   : Symbol("component"), m_pin1(0,0), m_designator(designator),
     m_designatorItem(NULL)
 {
+  // Component outlines are drawn without fill
+  m_brush = Qt::NoBrush;
   m_path = info.bodyPath;
   for (const auto& pin : info.pins) {
     m_path.addPath(pin.path);
@@ -52,7 +55,12 @@ QPainterPath ComponentSymbol::painterPath(void)
 void ComponentSymbol::paint(QPainter *painter, const QStyleOptionGraphicsItem *option,
     QWidget *widget)
 {
+  // Use base class rendering but always keep body outline only
+  QBrush savedBrush = m_brush;
+  m_brush = Qt::NoBrush;
   Symbol::paint(painter, option, widget);
+  m_brush = savedBrush;
+
   painter->setPen(Qt::NoPen);
   painter->setBrush(QBrush(m_pen.color()));
   painter->drawEllipse(m_pin1, 0.01, 0.01);
@@ -65,4 +73,23 @@ void ComponentSymbol::setPen(const QPen& pen)
   Symbol::setPen(pen);
   if (m_designatorItem)
     m_designatorItem->setBrush(pen.color());
+}
+
+void ComponentSymbol::mousePressEvent(QGraphicsSceneMouseEvent* event)
+{
+  GraphicsLayerScene* s = dynamic_cast<GraphicsLayerScene*>(scene());
+
+  if (!s || !s->highlight() || m_selected) {
+    return;
+  }
+
+  m_selected = true;
+  m_prevPen = m_pen;
+  m_prevBrush = m_brush;
+
+  setPen(QPen(Qt::blue, 0));
+  setBrush(Qt::NoBrush);
+  update();
+
+  s->updateSelection(this);
 }

--- a/src/symbol/componentsymbol.h
+++ b/src/symbol/componentsymbol.h
@@ -14,6 +14,7 @@ public:
   virtual void paint(QPainter *painter, const QStyleOptionGraphicsItem *option,
                      QWidget *widget);
   virtual void setPen(const QPen& pen) override;
+  virtual void mousePressEvent(QGraphicsSceneMouseEvent* event) override;
 private:
   QPainterPath m_path;
   QPointF m_pin1;


### PR DESCRIPTION
## Summary
- ensure component symbols use no fill by default
- call base drawing logic so segmentation fault is avoided
- prevent highlight from filling component outlines

## Testing
- `bash -n setup.sh`
- `bash setup.sh` *(partial output shown)*
- `qmake6 -version` *(fails: command not found)*
- `make -j2` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_684091693a6c83339cbb7812d3e67999