### PR TITLE
Fix layer color segfault

### DIFF
--- a/src/graphicsview/graphicslayer.cpp
+++ b/src/graphicsview/graphicslayer.cpp
@@ -73,7 +73,8 @@ void GraphicsLayer::setPen(const QPen& pen)
   m_pen = pen;
   QList<QGraphicsItem*> items = m_layerScene->items();
   for (int i = 0; i < items.size(); ++i) {
-    dynamic_cast<Symbol*>(items[i])->setPen(pen);
+    if (auto symbol = dynamic_cast<Symbol*>(items[i]))
+      symbol->setPen(pen);
   }
 }
 
@@ -88,7 +89,8 @@ void GraphicsLayer::setBrush(const QBrush& brush)
 
   QList<QGraphicsItem*> items = m_layerScene->items();
   for (int i = 0; i < items.size(); ++i) {
-    dynamic_cast<Symbol*>(items[i])->setBrush(tbrush);
+    if (auto symbol = dynamic_cast<Symbol*>(items[i]))
+      symbol->setBrush(tbrush);
   }
 }
 


### PR DESCRIPTION
## Summary
- fix crash when calling setPen/setBrush on graphics layers containing non-Symbol items

## Testing
- `bash -n setup.sh`
- `bash ./setup.sh`
- `qmake6 -version`
- `make -j2`

------
https://chatgpt.com/codex/tasks/task_e_684093dc42308333ba5fbe6b12628a5f