### PR TITLE
Fix background color setting

### DIFF
--- a/src/gui/viewerwindow.cpp
+++ b/src/gui/viewerwindow.cpp
@@ -207,7 +207,7 @@ QColor ViewerWindow::nextColor(void)
 
 void ViewerWindow::loadColorConfig()
 {
-  ctx.bg_color = QColor(SETTINGS->get("color", "BG").toString());
+  ctx.bg_color = QColor(SETTINGS->get("Color", "BG").toString());
 
   m_colors.clear();
   for(int i = 0; i < 6; ++i) {


### PR DESCRIPTION
## Summary
- fix color settings lookup for background color so user setting is applied

## Testing
- `bash -n setup.sh`
- `bash setup.sh`
- `qmake6 -version`
- `make -j2` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_684096ff06208333816ca335f9f149cc