### PR TITLE
Fix viewerwindow build error

### DIFF
--- a/src/gui/viewerwindow.cpp
+++ b/src/gui/viewerwindow.cpp
@@ -32,6 +32,9 @@
 #include <QRegularExpression>
 #include <QDebug>
 
+#include "packagedatastore.h"
+#include "odbpp/cachedparser.h"
+
 #include "context.h"
 #include "layerinfobox.h"
 #include "settingsdialog.h"


### PR DESCRIPTION
## Summary
- include package datastore parser headers
- run provided setup and build steps to ensure compilation

## Testing
- `bash -n setup.sh`
- `bash setup.sh`
- `qmake6 -version`
- `make -j2`

------
https://chatgpt.com/codex/tasks/task_e_68409e8d5b6083338ffc97d3070789af