### PR TITLE
Fix bottom component rotation

### DIFF
--- a/src/parser/componentrecord.cpp
+++ b/src/parser/componentrecord.cpp
@@ -33,7 +33,12 @@ Symbol* ComponentRecord::createSymbol(void) const
     t.scale(-1, 1);
     symbol->setTransform(t, true);
     // Mirror rotation for bottom side components
-    symbol->setRotation(0);
+    qreal mirroredRot = 180.0 - rot;
+    while (mirroredRot < 0)
+      mirroredRot += 360.0;
+    while (mirroredRot >= 360.0)
+      mirroredRot -= 360.0;
+    symbol->setRotation(mirroredRot);
   } else {
     symbol->setRotation(rot);
   }


### PR DESCRIPTION
## Summary
- mirror rotations properly on bottom-side components
- update setup

## Testing
- `bash -n setup.sh`
- `bash ./setup.sh`
- `qmake6 -version`
- `make -j2` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68419496157883338ebb2ec12ee66623