### PR TITLE
Fix mirrored rotation for bottom components

### DIFF
--- a/src/macros.h
+++ b/src/macros.h
@@ -26,14 +26,19 @@
 #define R2D (180.0 / M_PI)
 #define D2R (M_PI / 180.0)
 
-#define APPEND_ROW(root, header, data)                                      \
-  ({                                                                        \
-    QList<QStandardItem*> c;                                                \
-    QStandardItem* item = new QStandardItem(header);                        \
-    c.append(item);                                                         \
-    c.append(new QStandardItem(data));                                      \
-    root->appendRow(c);                                                     \
-    item;                                                                   \
-  })
+
+static inline QStandardItem* appendRow(QStandardItem* root,
+                                       const QString& header,
+                                       const QString& data)
+{
+  QList<QStandardItem*> c;
+  QStandardItem* item = new QStandardItem(header);
+  c.append(item);
+  c.append(new QStandardItem(data));
+  root->appendRow(c);
+  return item;
+}
+
+#define APPEND_ROW(root, header, data) appendRow(root, header, data)
 
 #endif /* __MACROS_H__ */

--- a/src/parser/componentrecord.cpp
+++ b/src/parser/componentrecord.cpp
@@ -33,7 +33,7 @@ Symbol* ComponentRecord::createSymbol(void) const
     t.scale(-1, 1);
     symbol->setTransform(t, true);
     // Mirror rotation for bottom side components
-    qreal mirroredRot = 180.0 - rot;
+    qreal mirroredRot = 360.0 - rot;
     while (mirroredRot < 0)
       mirroredRot += 360.0;
     while (mirroredRot >= 360.0)


### PR DESCRIPTION
## Summary
- correct mirrored rotation handling when rendering components on bottom layers
- replace non-standard APPEND_ROW macro with portable inline function for MSVC

## Testing
- `bash -n setup.sh`
- `bash setup.sh`
- `qmake6 -version`
- `make -j2` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68419dd0efc88333a0aa7c80627eb3aa