### PR TITLE
Fix macros.h compile error

### DIFF
--- a/src/macros.h
+++ b/src/macros.h
@@ -23,6 +23,10 @@
 #ifndef __MACROS_H__
 #define __MACROS_H__
 
+#include <QStandardItem>
+#include <QString>
+#include <QList>
+
 #define R2D (180.0 / M_PI)
 #define D2R (M_PI / 180.0)
 


### PR DESCRIPTION
## Summary
- include QStandardItem-related headers in `macros.h`

## Testing
- `bash -n setup.sh`
- `bash setup.sh` *(fails: package install permission issue)*
- `qmake6 -version` *(fails: command not found)*
- `make -j2` *(fails: no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_6841a6c7866c83339bacec4a00af11a1