### PR TITLE
Fix bottom layer orientation

### DIFF
--- a/src/graphicsview/layerfeatures.cpp
+++ b/src/graphicsview/layerfeatures.cpp
@@ -131,7 +131,9 @@ void LayerFeatures::loadStepAndRepeat(void)
 
         QTransform trans;
         if (mirror) {
-          trans.scale(-1, 1);
+          // Mirror steps on both axes when mirroring is requested
+          trans.scale(-1, -1);
+          angle += 180.0;
         }
         trans.rotate(angle);
         trans.translate(-step->x_datum(), step->y_datum());

--- a/src/parser/componentrecord.cpp
+++ b/src/parser/componentrecord.cpp
@@ -30,10 +30,11 @@ Symbol* ComponentRecord::createSymbol(void) const
   symbol->setPos(x, -y);
   if (mirror) {
     QTransform t;
-    t.scale(-1, 1);
+    // Flip both X and Y axis for bottom side components
+    t.scale(-1, -1);
     symbol->setTransform(t, true);
-    // Mirror rotation for bottom side components
-    qreal mirroredRot = 360.0 - rot;
+    // Adjust rotation to keep orientation consistent
+    qreal mirroredRot = 180.0 - rot;
     while (mirroredRot < 0)
       mirroredRot += 360.0;
     while (mirroredRot >= 360.0)

--- a/src/parser/padrecord.cpp
+++ b/src/parser/padrecord.cpp
@@ -50,11 +50,14 @@ Symbol* PadRecord::createSymbol(void) const
   Symbol* symbol = SymbolFactory::create(sym_name, polarity, attrib);
   symbol->setPos(x, -y);
 
+  int rotation = (orient % 4) * 90;
   if (orient >= M_0) {
     QTransform trans;
-    trans.scale(-1, 1);
+    // Bottom side pads need to be flipped in both axes
+    trans.scale(-1, -1);
     symbol->setTransform(trans);
+    rotation += 180;
   }
-  symbol->setRotation((orient % 4) * 90);
+  symbol->setRotation(rotation % 360);
   return symbol;
 }

--- a/src/parser/textrecord.cpp
+++ b/src/parser/textrecord.cpp
@@ -63,12 +63,15 @@ void TextRecord::setTransform(Symbol* symbol) const
 {
   symbol->setPos(x, -y);
 
+  int rotation = (orient % 4) * 90;
   if (orient >= M_0) {
     QTransform trans;
-    trans.scale(-1, 1);
+    // Flip both axes for bottom side text
+    trans.scale(-1, -1);
     symbol->setTransform(trans);
+    rotation += 180;
   }
-  symbol->setRotation((orient % 4) * 90);
+  symbol->setRotation(rotation % 360);
 }
 
 QString TextRecord::dynamicText(QString text)


### PR DESCRIPTION
## Summary
- flip bottom side components across both axes
- do the same for pads, text, and mirrored step/repeats
- normalize rotations after flipping

## Testing
- `bash -n setup.sh`
- `qmake6 -version`
- `make -j2` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_6841b56f26d48333a869ec5afaae0f13