### PR TITLE
Fix bottom layer component mirroring

### DIFF
--- a/src/graphicsview/components.cpp
+++ b/src/graphicsview/components.cpp
@@ -6,7 +6,8 @@
 #include "record.h"
 #include "context.h"
 
-Components::Components(QString step, QString path) : Symbol("components")
+Components::Components(QString step, QString path, bool bottomLayer)
+  : Symbol("components"), m_bottomLayer(bottomLayer)
 {
   ComponentsParser parser(ctx.loader->absPath(path.arg(step)));
   ComponentsDataStore* ds = parser.parse();
@@ -15,6 +16,11 @@ Components::Components(QString step, QString path) : Symbol("components")
 
   for (ComponentRecord* rec : ds->records()) {
     Symbol* s = rec->createSymbol();
+    if (m_bottomLayer) {
+      QTransform t;
+      t.scale(-1, 1); // flip horizontally for bottom layer
+      s->setTransform(t, true);
+    }
     addChild(s);
     m_symbols.append(s);
   }

--- a/src/graphicsview/components.h
+++ b/src/graphicsview/components.h
@@ -10,13 +10,14 @@ class QGraphicsScene;
 
 class Components : public Symbol {
 public:
-  Components(QString step, QString path);
+  Components(QString step, QString path, bool bottomLayer = false);
   ~Components();
 
   void addToScene(QGraphicsScene* scene);
 
 private:
   QList<Symbol*> m_symbols;
+  bool m_bottomLayer;
 };
 
 #endif /* __COMPONENTS_H__ */

--- a/src/graphicsview/layer.cpp
+++ b/src/graphicsview/layer.cpp
@@ -36,7 +36,11 @@ Layer::Layer(QString step, QString layer):
   if (QFile(featurePath).size() > 0) {
     m_features = new LayerFeatures(step, "steps/%1/layers/" + layer + "/features");
   } else {
-    m_features = new Components(step, "steps/%1/layers/" + layer + "/components");
+    bool bottom = layer.contains("bot", Qt::CaseInsensitive) ||
+                 layer.contains("bottom", Qt::CaseInsensitive);
+    m_features = new Components(step,
+                                "steps/%1/layers/" + layer + "/components",
+                                bottom);
   }
 
   if (auto lf = dynamic_cast<LayerFeatures*>(m_features))


### PR DESCRIPTION
## Summary
- detect when a component layer is on the bottom
- flip components horizontally when loading bottom layer

## Testing
- `bash -n setup.sh`
- `bash setup.sh >/tmp/setup.log`
- `qmake6 -version`
- `make -j2 >/tmp/make.log`

------
https://chatgpt.com/codex/tasks/task_e_6841cd5a139c8333a036cb47766e3203