### PR TITLE
Enable tooltips on component hover

### DIFF
--- a/src/symbol/symbol.cpp
+++ b/src/symbol/symbol.cpp
@@ -34,6 +34,8 @@ Symbol::Symbol(QString name, QString pattern, Polarity polarity,
   m_polarity(polarity), m_selected(false), m_attrib(attr)
 {
   setHandlesChildEvents(false);
+  // Enable hover events so tool tips appear for graphics items
+  setAcceptHoverEvents(true);
 
   // Since Layer will redraw all symbol visible everytime, using cache
   // will slow down the performance


### PR DESCRIPTION
## Summary
- ensure all symbols accept hover events so tooltips can display

## Testing
- `bash -n setup.sh`
- `bash setup.sh`
- `qmake6 -version`
- `qmake6 qcamber.pro`
- `make -j2` *(fails: Makefile build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6841d0d50a608333a9efc3e1e061a61e