### PR TITLE
Enable hover tooltips

### DIFF
--- a/src/graphicsview/odbppgraphicsview.cpp
+++ b/src/graphicsview/odbppgraphicsview.cpp
@@ -44,6 +44,10 @@ ODBPPGraphicsView::ODBPPGraphicsView(QWidget* parent): QGraphicsView(parent),
   setOptimizationFlags(DontSavePainterState);
   setTransformationAnchor(AnchorUnderMouse);
   setViewportUpdateMode(BoundingRectViewportUpdate);
+  // Enable mouse tracking so hover events (e.g., tooltips) work without
+  // requiring a mouse press.
+  setMouseTracking(true);
+  viewport()->setMouseTracking(true);
   setZoomMode(AreaZoom);
 
   connect(m_scene, SIGNAL(rectSelected(QRectF)), this,


### PR DESCRIPTION
## Summary
- enable mouse tracking in the main graphics view so tooltips show on hover

## Testing
- `bash -n setup.sh`
- `bash setup.sh`
- `qmake6 -version`
- `make -j2` *(fails: No targets specified)*

------
https://chatgpt.com/codex/tasks/task_e_6841d5301a48833387e040b242b83959