### PR TITLE
Fix tooltips for component symbols

### DIFF
--- a/src/graphicsview/odbppgraphicsview.cpp
+++ b/src/graphicsview/odbppgraphicsview.cpp
@@ -27,6 +27,8 @@
 #include "symbolfactory.h"
 
 #include <QScrollBar>
+#include <QHelpEvent>
+#include <QToolTip>
 
 ODBPPGraphicsView::ODBPPGraphicsView(QWidget* parent): QGraphicsView(parent),
   m_profile(NULL)
@@ -257,4 +259,23 @@ void ODBPPGraphicsView::resizeEvent(QResizeEvent* event)
 {
   updateLayerViewport();
   QGraphicsView::resizeEvent(event);
+}
+
+bool ODBPPGraphicsView::viewportEvent(QEvent* event)
+{
+  if (event->type() == QEvent::ToolTip) {
+    QHelpEvent* he = static_cast<QHelpEvent*>(event);
+    QPointF scenePos = mapToScene(he->pos());
+    for (GraphicsLayer* layer : m_scene->layers()) {
+      QGraphicsItem* item = layer->layerScene()->itemAt(scenePos, QTransform());
+      if (item && !item->toolTip().isEmpty()) {
+        QToolTip::showText(he->globalPos(), item->toolTip(), this);
+        return true;
+      }
+    }
+    QToolTip::hideText();
+    event->ignore();
+    return true;
+  }
+  return QGraphicsView::viewportEvent(event);
 }

--- a/src/graphicsview/odbppgraphicsview.h
+++ b/src/graphicsview/odbppgraphicsview.h
@@ -67,6 +67,7 @@ protected:
   virtual void wheelEvent(QWheelEvent* event);
   virtual void keyPressEvent(QKeyEvent* event);
   virtual void resizeEvent(QResizeEvent* event);
+  virtual bool viewportEvent(QEvent* event) override;
 
 private:
   ODBPPGraphicsScene* m_scene;


### PR DESCRIPTION
## Summary
- intercept QEvent::ToolTip in `ODBPPGraphicsView`
- search component layers for hovered item and show its tooltip

## Testing
- `bash -n setup.sh`
- `./setup.sh`
- `qmake6 -version`
- `make -j2`

------
https://chatgpt.com/codex/tasks/task_e_6841d7bcfbe08333a8358f37f3d1f981