### PR TITLE
Fix layer type initialization

### DIFF
--- a/src/gui/layerinfobox.cpp
+++ b/src/gui/layerinfobox.cpp
@@ -39,7 +39,7 @@ LayerInfoBox::LayerInfoBox(const QString& name, const QString& step,
     const QString& type):
     QWidget(NULL),
     ui(new Ui::LayerInfoBox),
-    m_name(name), m_step(step), m_layer(NULL), m_checked(false)
+    m_name(name), m_step(step), m_type(type), m_layer(NULL), m_checked(false)
 {
   ui->setupUi(this);
   ui->layerName->setText(name);


### PR DESCRIPTION
## Summary
- store the layer type when constructing `LayerInfoBox`

## Testing
- `bash -n setup.sh`
- `bash ./setup.sh`
- `qmake6 -version`
- `make -j2` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_6841ddf5e4d48333b7254169dfa9ebcc